### PR TITLE
Moved tests into separate functions

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Code complexity
         run: poetry run complexipy .
 
-      - name: Run doctests
+      - name: Run tests
         run: poetry run pytest

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -41,3 +41,15 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: htmlcov/
+
+      - name: Upload Pytest Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-results
+          path: pytest-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # Python
-.venv
-dist
-__pycache__
 .hypothesis
+.venv
+__pycache__
+dist
 
 # Pytest
+.coverage
+htmlcov
+pytest-results.xml
 site

--- a/poetry.lock
+++ b/poetry.lock
@@ -405,6 +405,83 @@ test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
 test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
 
 [[package]]
+name = "coverage"
+version = "7.6.8"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "coverage-7.6.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b39e6011cd06822eb964d038d5dff5da5d98652b81f5ecd439277b32361a3a50"},
+    {file = "coverage-7.6.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:63c19702db10ad79151a059d2d6336fe0c470f2e18d0d4d1a57f7f9713875dcf"},
+    {file = "coverage-7.6.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3985b9be361d8fb6b2d1adc9924d01dec575a1d7453a14cccd73225cb79243ee"},
+    {file = "coverage-7.6.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:644ec81edec0f4ad17d51c838a7d01e42811054543b76d4ba2c5d6af741ce2a6"},
+    {file = "coverage-7.6.8-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f188a2402f8359cf0c4b1fe89eea40dc13b52e7b4fd4812450da9fcd210181d"},
+    {file = "coverage-7.6.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e19122296822deafce89a0c5e8685704c067ae65d45e79718c92df7b3ec3d331"},
+    {file = "coverage-7.6.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:13618bed0c38acc418896005732e565b317aa9e98d855a0e9f211a7ffc2d6638"},
+    {file = "coverage-7.6.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:193e3bffca48ad74b8c764fb4492dd875038a2f9925530cb094db92bb5e47bed"},
+    {file = "coverage-7.6.8-cp310-cp310-win32.whl", hash = "sha256:3988665ee376abce49613701336544041f2117de7b7fbfe91b93d8ff8b151c8e"},
+    {file = "coverage-7.6.8-cp310-cp310-win_amd64.whl", hash = "sha256:f56f49b2553d7dd85fd86e029515a221e5c1f8cb3d9c38b470bc38bde7b8445a"},
+    {file = "coverage-7.6.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:86cffe9c6dfcfe22e28027069725c7f57f4b868a3f86e81d1c62462764dc46d4"},
+    {file = "coverage-7.6.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d82ab6816c3277dc962cfcdc85b1efa0e5f50fb2c449432deaf2398a2928ab94"},
+    {file = "coverage-7.6.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13690e923a3932e4fad4c0ebfb9cb5988e03d9dcb4c5150b5fcbf58fd8bddfc4"},
+    {file = "coverage-7.6.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4be32da0c3827ac9132bb488d331cb32e8d9638dd41a0557c5569d57cf22c9c1"},
+    {file = "coverage-7.6.8-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44e6c85bbdc809383b509d732b06419fb4544dca29ebe18480379633623baafb"},
+    {file = "coverage-7.6.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:768939f7c4353c0fac2f7c37897e10b1414b571fd85dd9fc49e6a87e37a2e0d8"},
+    {file = "coverage-7.6.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e44961e36cb13c495806d4cac67640ac2866cb99044e210895b506c26ee63d3a"},
+    {file = "coverage-7.6.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ea8bb1ab9558374c0ab591783808511d135a833c3ca64a18ec927f20c4030f0"},
+    {file = "coverage-7.6.8-cp311-cp311-win32.whl", hash = "sha256:629a1ba2115dce8bf75a5cce9f2486ae483cb89c0145795603d6554bdc83e801"},
+    {file = "coverage-7.6.8-cp311-cp311-win_amd64.whl", hash = "sha256:fb9fc32399dca861584d96eccd6c980b69bbcd7c228d06fb74fe53e007aa8ef9"},
+    {file = "coverage-7.6.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e683e6ecc587643f8cde8f5da6768e9d165cd31edf39ee90ed7034f9ca0eefee"},
+    {file = "coverage-7.6.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1defe91d41ce1bd44b40fabf071e6a01a5aa14de4a31b986aa9dfd1b3e3e414a"},
+    {file = "coverage-7.6.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7ad66e8e50225ebf4236368cc43c37f59d5e6728f15f6e258c8639fa0dd8e6d"},
+    {file = "coverage-7.6.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3fe47da3e4fda5f1abb5709c156eca207eacf8007304ce3019eb001e7a7204cb"},
+    {file = "coverage-7.6.8-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:202a2d645c5a46b84992f55b0a3affe4f0ba6b4c611abec32ee88358db4bb649"},
+    {file = "coverage-7.6.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4674f0daa1823c295845b6a740d98a840d7a1c11df00d1fd62614545c1583787"},
+    {file = "coverage-7.6.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:74610105ebd6f33d7c10f8907afed696e79c59e3043c5f20eaa3a46fddf33b4c"},
+    {file = "coverage-7.6.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37cda8712145917105e07aab96388ae76e787270ec04bcb9d5cc786d7cbb8443"},
+    {file = "coverage-7.6.8-cp312-cp312-win32.whl", hash = "sha256:9e89d5c8509fbd6c03d0dd1972925b22f50db0792ce06324ba069f10787429ad"},
+    {file = "coverage-7.6.8-cp312-cp312-win_amd64.whl", hash = "sha256:379c111d3558272a2cae3d8e57e6b6e6f4fe652905692d54bad5ea0ca37c5ad4"},
+    {file = "coverage-7.6.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b0c69f4f724c64dfbfe79f5dfb503b42fe6127b8d479b2677f2b227478db2eb"},
+    {file = "coverage-7.6.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c15b32a7aca8038ed7644f854bf17b663bc38e1671b5d6f43f9a2b2bd0c46f63"},
+    {file = "coverage-7.6.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63068a11171e4276f6ece913bde059e77c713b48c3a848814a6537f35afb8365"},
+    {file = "coverage-7.6.8-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f4548c5ead23ad13fb7a2c8ea541357474ec13c2b736feb02e19a3085fac002"},
+    {file = "coverage-7.6.8-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b4b4299dd0d2c67caaaf286d58aef5e75b125b95615dda4542561a5a566a1e3"},
+    {file = "coverage-7.6.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9ebfb2507751f7196995142f057d1324afdab56db1d9743aab7f50289abd022"},
+    {file = "coverage-7.6.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c1b4474beee02ede1eef86c25ad4600a424fe36cff01a6103cb4533c6bf0169e"},
+    {file = "coverage-7.6.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d9fd2547e6decdbf985d579cf3fc78e4c1d662b9b0ff7cc7862baaab71c9cc5b"},
+    {file = "coverage-7.6.8-cp313-cp313-win32.whl", hash = "sha256:8aae5aea53cbfe024919715eca696b1a3201886ce83790537d1c3668459c7146"},
+    {file = "coverage-7.6.8-cp313-cp313-win_amd64.whl", hash = "sha256:ae270e79f7e169ccfe23284ff5ea2d52a6f401dc01b337efb54b3783e2ce3f28"},
+    {file = "coverage-7.6.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de38add67a0af869b0d79c525d3e4588ac1ffa92f39116dbe0ed9753f26eba7d"},
+    {file = "coverage-7.6.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b07c25d52b1c16ce5de088046cd2432b30f9ad5e224ff17c8f496d9cb7d1d451"},
+    {file = "coverage-7.6.8-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62a66ff235e4c2e37ed3b6104d8b478d767ff73838d1222132a7a026aa548764"},
+    {file = "coverage-7.6.8-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09b9f848b28081e7b975a3626e9081574a7b9196cde26604540582da60235fdf"},
+    {file = "coverage-7.6.8-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:093896e530c38c8e9c996901858ac63f3d4171268db2c9c8b373a228f459bbc5"},
+    {file = "coverage-7.6.8-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a7b8ac36fd688c8361cbc7bf1cb5866977ece6e0b17c34aa0df58bda4fa18a4"},
+    {file = "coverage-7.6.8-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:38c51297b35b3ed91670e1e4efb702b790002e3245a28c76e627478aa3c10d83"},
+    {file = "coverage-7.6.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2e4e0f60cb4bd7396108823548e82fdab72d4d8a65e58e2c19bbbc2f1e2bfa4b"},
+    {file = "coverage-7.6.8-cp313-cp313t-win32.whl", hash = "sha256:6535d996f6537ecb298b4e287a855f37deaf64ff007162ec0afb9ab8ba3b8b71"},
+    {file = "coverage-7.6.8-cp313-cp313t-win_amd64.whl", hash = "sha256:c79c0685f142ca53256722a384540832420dff4ab15fec1863d7e5bc8691bdcc"},
+    {file = "coverage-7.6.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ac47fa29d8d41059ea3df65bd3ade92f97ee4910ed638e87075b8e8ce69599e"},
+    {file = "coverage-7.6.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:24eda3a24a38157eee639ca9afe45eefa8d2420d49468819ac5f88b10de84f4c"},
+    {file = "coverage-7.6.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4c81ed2820b9023a9a90717020315e63b17b18c274a332e3b6437d7ff70abe0"},
+    {file = "coverage-7.6.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd55f8fc8fa494958772a2a7302b0354ab16e0b9272b3c3d83cdb5bec5bd1779"},
+    {file = "coverage-7.6.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f39e2f3530ed1626c66e7493be7a8423b023ca852aacdc91fb30162c350d2a92"},
+    {file = "coverage-7.6.8-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:716a78a342679cd1177bc8c2fe957e0ab91405bd43a17094324845200b2fddf4"},
+    {file = "coverage-7.6.8-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:177f01eeaa3aee4a5ffb0d1439c5952b53d5010f86e9d2667963e632e30082cc"},
+    {file = "coverage-7.6.8-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:912e95017ff51dc3d7b6e2be158dedc889d9a5cc3382445589ce554f1a34c0ea"},
+    {file = "coverage-7.6.8-cp39-cp39-win32.whl", hash = "sha256:4db3ed6a907b555e57cc2e6f14dc3a4c2458cdad8919e40b5357ab9b6db6c43e"},
+    {file = "coverage-7.6.8-cp39-cp39-win_amd64.whl", hash = "sha256:428ac484592f780e8cd7b6b14eb568f7c85460c92e2a37cb0c0e5186e1a0d076"},
+    {file = "coverage-7.6.8-pp39.pp310-none-any.whl", hash = "sha256:5c52a036535d12590c32c49209e79cabaad9f9ad8aa4cbd875b68c4d67a9cbce"},
+    {file = "coverage-7.6.8.tar.gz", hash = "sha256:8b2b8503edb06822c86d82fa64a4a5cb0760bb8f31f26e138ec743f422f37cfc"},
+]
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
@@ -1557,6 +1634,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "6.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"},
+    {file = "pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35"},
+]
+
+[package.dependencies]
+coverage = {version = ">=7.5", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1934,17 +2029,6 @@ files = [
 ]
 
 [[package]]
-name = "tzdata"
-version = "2024.2"
-description = "Provider of IANA time zone data"
-optional = false
-python-versions = ">=2"
-files = [
-    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
-    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
-]
-
-[[package]]
 name = "urllib3"
 version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2006,4 +2090,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "06dbd5056315f99ae33bee7f0fee39a55a811f2f09d6d9a2c8f45be77be1cd16"
+content-hash = "a1d34a4131076eda906ccecaeabf6e5023a26290da05058dc1dbfa05d667d9cf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ isort = "^5.13.2"
 mkdocs-material = "^9.5.42"
 mkdocstrings-python = "^1.11.1"
 pytest = "^8.3.3"
+pytest-cov = "^6.0.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -31,7 +32,13 @@ build-backend = "poetry.core.masonry.api"
 
 # Testing
 [tool.pytest.ini_options]
-addopts = ["--cov-report=html", "--cov=lost_spc", "--doctest-modules", "--ff"]
+addopts = [
+  "--cov-report=html",
+  "--cov=lost_spc",
+  "--junitxml=pytest-results.xml",
+  "--doctest-modules",
+  "--ff",
+]
 
 # Linting
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ build-backend = "poetry.core.masonry.api"
 
 # Testing
 [tool.pytest.ini_options]
-addopts = "--doctest-modules"
+addopts = ["--cov-report=html", "--cov=lost_spc", "--doctest-modules", "--ff"]
 
 # Linting
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,23 +7,23 @@ license = "GPL-3.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
-numpy = "^2.1.2"
-scipy = "^1.14.1"
-pandas = "^2.2.3"
 matplotlib = "^3.9.2"
+numpy = "^2.1.2"
+pandas = "^2.2.3"
+python = "^3.10"
+scipy = "^1.14.1"
 
 [tool.poetry.group.dev.dependencies]
-mkdocstrings-python = "^1.11.1"
-mkdocs-material = "^9.5.42"
-pytest = "^8.3.3"
-hypothesis = "^6.115.3"
-black = "^24.10.0"
-flake8 = "^7.1.1"
 basedpyright = "^1.21.0"
-isort = "^5.13.2"
-flake8-pyproject = "^1.2.3"
+black = "^24.10.0"
 complexipy = "^0.5.0"
+flake8 = "^7.1.1"
+flake8-pyproject = "^1.2.3"
+hypothesis = "^6.115.3"
+isort = "^5.13.2"
+mkdocs-material = "^9.5.42"
+mkdocstrings-python = "^1.11.1"
+pytest = "^8.3.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ complexipy = "^0.5.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+# Testing
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"
+
+# Linting
 [tool.flake8]
 max-line-length = 100
 exclude = [".git", "__pycache__"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --doctest-modules

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -9,63 +9,61 @@ import lost_spc.constants as const
 import lost_spc.plots as plot
 import lost_spc.utils as ut
 
-df = pd.read_csv(str(Path("./tests/vane.txt")), sep=" ", header=None)
-print(df.head())
-array = df.to_numpy()
-sample_size = ut.get_sample_size(array)
-n = sample_size.n
-m = sample_size.m
-print("Zeilen x Spalten: ", n, "x", m)
 
-# %% a) mean, range, std
-ybar = val.calculate_means(array)
-R = val.calculate_ranges(array)
-std = val.calculate_standard_deviations(array)
-print(ybar)
-print(R)
-print(std)
+def test_cards():
+    """Sollte noch aufgeteilt werden in mehrere Tests für eine bessere Übersicht"""
+    df = pd.read_csv(str(Path("./tests/vane.txt")), sep=" ", header=None)
+    print(df.head())
+    array = df.to_numpy()
+    sample_size = ut.get_sample_size(array)
+    n = sample_size.n
+    m = sample_size.m
+    print("Zeilen x Spalten: ", n, "x", m)
 
-d = const.get_d(m)
-d2 = d.d2
-d3 = d.d3
-print(d2, d3)
+    # %% a) mean, range, std
+    ybar = val.calculate_means(array)
+    R = val.calculate_ranges(array)
+    std = val.calculate_standard_deviations(array)
+    print(ybar)
+    print(R)
+    print(std)
 
-# %% b) R-chart
-control_limits = limits.calculate_control_limits(array, chart_type="R")
-UCL = control_limits["UCL"]
-CL = control_limits["CL"]
-LCL = control_limits["LCL"]
+    d = const.get_d(m)
+    d2 = d.d2
+    d3 = d.d3
+    print(d2, d3)
 
-print("R-Karte UCL: ", UCL)
-print("R-Karte CL: ", CL)
-print("R-Karte LCL: ", LCL)
+    # %% b) R-chart
+    control_limits = limits.calculate_control_limits(array, chart_type="R")
+    UCL = control_limits["UCL"]
+    CL = control_limits["CL"]
+    LCL = control_limits["LCL"]
 
-# plots
-# Erstelle eine Figur mit Subplots
-fig, axes = plt.subplots(1, 2, figsize=(8, 10))
+    print("R-Karte UCL: ", UCL)
+    print("R-Karte CL: ", CL)
+    print("R-Karte LCL: ", LCL)
 
-# Erster Subplot: R-Chart
-plot.shewhart_card(UCL, CL, LCL, R, title="R-chart", ylabel=r"$R_i$", ax=axes[0])
+    # plots
+    # Erstelle eine Figur mit Subplots
+    _, axes = plt.subplots(1, 2, figsize=(8, 10))
 
-# Zweiter Subplot: R-Karte aus der Klasse
-rchart = plot.cards.R()
-rchart.fit(array)
-rchart.transform(array, ax=axes[1])
+    # Erster Subplot: R-Chart
+    plot.shewhart_card(UCL, CL, LCL, R, title="R-chart", ylabel=r"$R_i$", ax=axes[0])
 
-# Subplots optimieren und anzeigen
-plt.tight_layout()
-plt.show()
+    # Zweiter Subplot: R-Karte aus der Klasse
+    rchart = plot.cards.R()
+    rchart.fit(array)
+    rchart.transform(array, ax=axes[1])
 
-plot.plots.plot_histogram_normal(array.flatten())
-plt.show()
+    # Subplots optimieren und anzeigen
+    plt.tight_layout()
+    plot.plots.plot_histogram_normal(array.flatten())
+    plot.plots.plot_qq_plot(array.flatten())
 
-plot.plots.plot_qq_plot(array.flatten())
-plt.show()
+    print(limits.get_confidence_interval_cp(val.calculate_cp(UCL, LCL, std.mean()), array, 0.95))
 
-print(limits.get_confidence_interval_cp(val.calculate_cp(UCL, LCL, std.mean()), array, 0.95))
-
-array.reshape(-1)
-ewmachart = plot.cards.EWMA(lambda_=0.2, plot_calibration_data=True)
-ewmachart.fit(array)
-ewmachart.transform(array + 2)
-plt.show()
+    array.reshape(-1)
+    ewmachart = plot.cards.EWMA(lambda_=0.2, plot_calibration_data=True)
+    ewmachart.fit(array)
+    ewmachart.transform(array + 2)
+    # plt.show()

--- a/tests/test_power_oc_arl.py
+++ b/tests/test_power_oc_arl.py
@@ -3,88 +3,96 @@ import numpy as np
 
 from lost_spc.calculations.spc_values import ARL, ARL_R, oc, oc_r, power
 
-# power, OC und ARL x_bar-Karte
-k = np.linspace(-4, 4, 500)
-sigma = 0.0262
-mu = 1.2023 + k * sigma
 
-_, ax = plt.subplots(1, 3, figsize=(15, 5))
+def test_power_oc_arl():
+    """power, OC und ARL x_bar-Karte"""
+    plt.close("all")
+    k = np.linspace(-4, 4, 500)
+    sigma = 0.0262
+    mu = 1.2023 + k * sigma
 
-ax[0].plot(mu, power(k, 5), label="m = 5")
-ax[0].plot(mu, power(k, 10), label="m = 10")
-ax[0].plot(mu, power(k, 15), label="m = 15")
+    _, ax = plt.subplots(1, 3, figsize=(15, 5))
 
-ax[0].legend()
-ax[0].grid()
-ax[0].set_xlabel("Wahrer Erwartungswert des Prozessmerkmales")
-ax[0].set_title(r"Gütefunktion für die $\bar x$-Karte")
+    ax[0].plot(mu, power(k, 5), label="m = 5")
+    ax[0].plot(mu, power(k, 10), label="m = 10")
+    ax[0].plot(mu, power(k, 15), label="m = 15")
 
-k0 = np.linspace(0, 4)
-ax[1].plot(k0, oc(k0, 5), label="m = 5")
-ax[1].plot(k0, oc(k0, 10), label="m = 10")
-ax[1].plot(k0, oc(k0, 15), label="m = 15")
+    ax[0].legend()
+    ax[0].grid()
+    ax[0].set_xlabel("Wahrer Erwartungswert des Prozessmerkmales")
+    ax[0].set_title(r"Gütefunktion für die $\bar x$-Karte")
 
-ax[1].legend()
-ax[1].grid()
-ax[1].set_xlabel(r"Abweichung von $\mu_0$ in Vielfachen von $\sigma$")
-ax[1].set_title(r"Operationscharakteristik für die $\bar x$-Karte")
+    k0 = np.linspace(0, 4)
+    ax[1].plot(k0, oc(k0, 5), label="m = 5")
+    ax[1].plot(k0, oc(k0, 10), label="m = 10")
+    ax[1].plot(k0, oc(k0, 15), label="m = 15")
 
-ax[2].plot(mu, ARL(k=k, m=5))
-ax[2].grid()
-ax[2].set_xlabel("Wahrer Erwartungswert des Prozesses")
-ax[2].set_title(r"Durchschnittliche Lauflänge für die $\bar x$-Karte")
-plt.tight_layout()
-plt.show()
+    ax[1].legend()
+    ax[1].grid()
+    ax[1].set_xlabel(r"Abweichung von $\mu_0$ in Vielfachen von $\sigma$")
+    ax[1].set_title(r"Operationscharakteristik für die $\bar x$-Karte")
 
-# power, OC und ARL x_bar-Karte R-Karte
-_, ax = plt.subplots(1, 2, figsize=(15, 5))
-
-lam = np.linspace(1, 5, 500)
-ax[0].plot(lam, oc_r(lam=lam, m=5), label="m=5")
-ax[0].plot(lam, oc_r(lam=lam, m=10), label="m=10")
-ax[0].plot(lam, oc_r(lam=lam, m=15), label="m=15")
-
-ax[0].legend()
-ax[0].grid()
-ax[0].set_xlabel("Verhältnis der Prozessstreuung in Phase II bzgl. Phase I")
-ax[0].set_title(r"Operationscharakteristik für die $R$-Karte")
-
-ax[1].plot(lam, ARL_R(lam=lam, m=5), label="m=5")
-ax[1].plot(lam, ARL_R(lam=lam, m=10), label="m=10")
-ax[1].plot(lam, ARL_R(lam=lam, m=15), label="m=15")
-
-ax[1].legend()
-ax[1].grid()
-ax[1].set_xlabel("Verhältnis der Prozessstreuung in Phase II bzgl. Phase I")
-ax[1].set_title(r"Mittlere Lauflänge der $R$-Karte")
-plt.tight_layout()
-plt.show()
+    ax[2].plot(mu, ARL(k=k, m=5))
+    ax[2].grid()
+    ax[2].set_xlabel("Wahrer Erwartungswert des Prozesses")
+    ax[2].set_title(r"Durchschnittliche Lauflänge für die $\bar x$-Karte")
+    plt.tight_layout()
+    # plt.show()
 
 
-# Berechnung der ARL für verschiedene m-Werte und Darstellung
-_, ax = plt.subplots(1, 2, figsize=(15, 5))
+def test_power_oc_arl_r():
+    """power, OC und ARL x_bar-Karte R-Karte"""
+    plt.close("all")
+    _, ax = plt.subplots(1, 2, figsize=(15, 5))
 
-# X̄ control chart
-k = np.linspace(0, 2, 200)
+    lam = np.linspace(1, 5, 500)
+    ax[0].plot(lam, oc_r(lam=lam, m=5), label="m=5")
+    ax[0].plot(lam, oc_r(lam=lam, m=10), label="m=10")
+    ax[0].plot(lam, oc_r(lam=lam, m=15), label="m=15")
 
-for m in [2, 3, 5, 10]:
-    ax[0].plot(k, ARL(k=k, m=m), label=f"m={m}")
+    ax[0].legend()
+    ax[0].grid()
+    ax[0].set_xlabel("Verhältnis der Prozessstreuung in Phase II bzgl. Phase I")
+    ax[0].set_title(r"Operationscharakteristik für die $R$-Karte")
 
-ax[0].legend()
-ax[0].grid()
-ax[0].set_xlabel("$k = (\\mu_1 - \\mu_0) / \\sigma$")
-ax[0].set_title("ARL der $\\bar{X}$-Karte")
+    ax[1].plot(lam, ARL_R(lam=lam, m=5), label="m=5")
+    ax[1].plot(lam, ARL_R(lam=lam, m=10), label="m=10")
+    ax[1].plot(lam, ARL_R(lam=lam, m=15), label="m=15")
 
-# R-Karte
-lam = np.linspace(1, 2, 500)
+    ax[1].legend()
+    ax[1].grid()
+    ax[1].set_xlabel("Verhältnis der Prozessstreuung in Phase II bzgl. Phase I")
+    ax[1].set_title(r"Mittlere Lauflänge der $R$-Karte")
+    plt.tight_layout()
+    # plt.show()
 
-for m in [2, 3, 5, 10, 20]:
-    ax[1].plot(lam, ARL_R(lam=lam, m=m), label=f"m={m}")
 
-ax[1].legend()
-ax[1].grid()
-ax[1].set_xlabel("$\\lambda = \\sigma_1 / \\sigma_0$")
-ax[0].set_ylabel("ARL")
-ax[1].set_title("ARL der R-Karte")
-plt.tight_layout()
-plt.show()
+def test_arl_multiple_m():
+    """Berechnung der ARL für verschiedene m-Werte und Darstellung"""
+    plt.close("all")
+    _, ax = plt.subplots(1, 2, figsize=(15, 5))
+
+    # X̄ control chart
+    k = np.linspace(0, 2, 200)
+
+    for m in [2, 3, 5, 10]:
+        ax[0].plot(k, ARL(k=k, m=m), label=f"m={m}")
+
+    ax[0].legend()
+    ax[0].grid()
+    ax[0].set_xlabel("$k = (\\mu_1 - \\mu_0) / \\sigma$")
+    ax[0].set_title("ARL der $\\bar{X}$-Karte")
+
+    # R-Karte
+    lam = np.linspace(1, 2, 500)
+
+    for m in [2, 3, 5, 10, 20]:
+        ax[1].plot(lam, ARL_R(lam=lam, m=m), label=f"m={m}")
+
+    ax[1].legend()
+    ax[1].grid()
+    ax[1].set_xlabel("$\\lambda = \\sigma_1 / \\sigma_0$")
+    ax[0].set_ylabel("ARL")
+    ax[1].set_title("ARL der R-Karte")
+    plt.tight_layout()
+    # plt.show()


### PR DESCRIPTION
In general, each test should be in it's own function, named `test_....():`. This will produce nicer outputs from pytest and the testrunner can skip specific tests if required.